### PR TITLE
Allow to set colourID also when cracking (avoid magic numbers)

### DIFF
--- a/core/crack.py
+++ b/core/crack.py
@@ -93,7 +93,7 @@ class CIntruderCrack(object):
             for y in range(im.size[0]):
                 pix = im.getpixel((y, x))
                 temp[pix] = pix
-                if pix == 3: # pixel colour id 
+                if pix == int(options.setids):  # pixel colour id 
                     im2.putpixel((y, x), 0)
         inletter = False
         foundletter = False
@@ -103,7 +103,7 @@ class CIntruderCrack(object):
         for y in range(im2.size[0]): # slice across
             for x in range(im2.size[1]): # slice down
                 pix = im2.getpixel((y, x))
-                if pix != 255:
+                if pix == 0:
                     inletter = True
             if foundletter == False and inletter == True:
                 foundletter = True

--- a/core/js/web.js
+++ b/core/js/web.js
@@ -261,6 +261,7 @@ function CrackCaptchas(){
         }else {
          tor="off";
         }
+        colourID=document.getElementById("set_id3").value;
         if(document.getElementById("verbose3").checked) 
         {
          verbose="on";
@@ -276,7 +277,7 @@ function CrackCaptchas(){
         if(source_file==""){
         source_file="off"
         }
-        params="crack_url="+escape(crack_url)+"&source_file="+escape(source_file)+"&module="+escape(module)+"&tor="+escape(tor)+"&verbose="+escape(verbose)+"&xml="+escape(xml);
+        params="crack_url="+escape(crack_url)+"&source_file="+escape(source_file)+"&colourID="+escape(colourID)+"&module="+escape(module)+"&tor="+escape(tor)+"&verbose="+escape(verbose)+"&xml="+escape(xml);
          }
          runCommandX("cmd_crack",params);
          if(source_file=="off"){

--- a/core/webgui.py
+++ b/core/webgui.py
@@ -241,6 +241,15 @@ URL: <input type="radio" onclick="javascript:CrackingCheck();" name="cracking_so
 </td>
 </tr>
 <tr>
+<td align="right">Advanced OCR: </td>
+ <td align="center">
+<table cellpadding="5" cellspacing="5">
+<tr>
+ <td>Set Colour ID: <input type="text" name="set_id3" id="set_id3" size="2" value="1" placeholder="Ex: 1"></td>
+</tr></table>
+</td>
+</tr>
+<tr>
  <td align="right">Debug: <input type="checkbox" name="verbose3" id="verbose3"></td>
  <td><center><input type="submit" class="button" value="Crack it!" onclick="CrackCaptchas()"></center></td>
 </tr>
@@ -521,6 +530,8 @@ function runCommandX(cmd,params) {
                 cmd_options = cmd_options + "--mod='" + pGet["module"] + "' "
             if not pGet["xml"]=="off":
                 cmd_options = cmd_options + "--xml='" + pGet["xml"] + "' "
+            if not pGet["colourID"]=="off":
+                cmd_options = cmd_options + "--set-id='" + pGet["colourID"] + "' "
             if pGet["source_file"]=="off": # from remote url source
                 runcmd = "(python -i cintruder --crack '"+pGet["crack_url"]+"' " + cmd_options + "|tee /tmp/out) &"
             else: # from local source 


### PR DESCRIPTION
The colourID (colour index) was set to magic number 3 in core/crack.py#L96 and was only available to be changed under the web GUI in the "Train" tab (an option missing in "Crack" tab, though)