### PR TITLE
Add a one-click option to move all typed letters to dictionary

### DIFF
--- a/core/webgui.py
+++ b/core/webgui.py
@@ -241,6 +241,15 @@ URL: <input type="radio" onclick="javascript:CrackingCheck();" name="cracking_so
 </td>
 </tr>
 <tr>
+<td align="right">Advanced OCR: </td>
+ <td align="center">
+<table cellpadding="5" cellspacing="5">
+<tr>
+ <td>Set Colour ID: <input type="text" name="set_id3" id="set_id3" size="2" value="1" placeholder="Ex: 1"></td>
+</tr></table>
+</td>
+</tr>
+<tr>
  <td align="right">Debug: <input type="checkbox" name="verbose3" id="verbose3"></td>
  <td><center><input type="submit" class="button" value="Crack it!" onclick="CrackCaptchas()"></center></td>
 </tr>
@@ -313,7 +322,35 @@ runCommandX("cmd_remove_ocr",params);
 setTimeout(function() { Reload(word) }, 2000); // delay 2
 }
 </script>
-<script language="javascript">function ViewWord(word) {window.open(word,"_blank","fulscreen=no, titlebar=yes, top=180, left=320, width=720, height=460, resizable=yes", false);}</script></head><body><table width='100%'><tr><td align='center'><font color='white'><div id="cmdOut"></div></font></td></tr><tr><td><br><center><a href='javascript:runCommandX("cmd_dict");'><font color="cyan"><u>View Dictionary Info</u></font></a></center></td></tr><tr><td>"""+str("".join(self.list_words()))+"""</td></tr></table></body></html>"""
+
+<script
+  src="https://code.jquery.com/jquery-2.2.4.min.js"
+  integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44="
+  crossorigin="anonymous"></script>
+
+<script language="javascript">
+
+function _x(STR_XPATH) {
+    var xresult = document.evaluate(STR_XPATH, document, null, XPathResult.ANY_TYPE, null);
+    var xnodes = [];
+    var xres;
+    while (xres = xresult.iterateNext()) {
+        xnodes.push(xres);
+    }
+
+    return xnodes;
+}
+
+function sendAll(){
+    var botones_ = $(_x('//*[contains(@onclick, "MoveOCR")]'));
+    var botones = jQuery.makeArray( botones_ );
+    
+    // var botones = document.evaluate('//*[contains(@onclick, "MoveOCR")]', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.innerHTML; 
+    botones.forEach( e => e.click() );
+};
+
+function ViewWord(word) {window.open(word,"_blank","fulscreen=no, titlebar=yes, top=180, left=320, width=720, height=460, resizable=yes", false);}</script></head><body><table width='100%'><tr><td align='center'> <input type='button' value="Add all" onclick="javascript:sendAll()">
+  <font color='white'><div id="cmdOut"></div></font></td></tr><tr><td><br><center><a href='javascript:runCommandX("cmd_dict");'><font color="cyan"><u>View Dictionary Info</u></font></a></center></td></tr><tr><td>"""+str("".join(self.list_words()))+"""</td></tr></table></body></html>"""
 
         self.pages["/lib.js"] = """function loadXMLDoc() {
         var xmlhttp;
@@ -521,6 +558,8 @@ function runCommandX(cmd,params) {
                 cmd_options = cmd_options + "--mod='" + pGet["module"] + "' "
             if not pGet["xml"]=="off":
                 cmd_options = cmd_options + "--xml='" + pGet["xml"] + "' "
+            if not pGet["colourID"]=="off":
+                cmd_options = cmd_options + "--set-id='" + pGet["colourID"] + "' "
             if pGet["source_file"]=="off": # from remote url source
                 runcmd = "(python -i cintruder --crack '"+pGet["crack_url"]+"' " + cmd_options + "|tee /tmp/out) &"
             else: # from local source 


### PR DESCRIPTION
Now (before this PR), when training, the user has to click on each button for adding to the dictionary the associated letter ("word" in cintruder lingo) of each symbol. If the captcha is composed of 5 symbols, the user has to click 5 times on each "ADD!" button (and wait each time for finishing the operation). This PR adds a new "Add all" button to ease the procedure. Now, after typing the associated letters, the user has to click only once the "Add all" button and all the letters will be correctly added to the dictionary (also avoiding the 5x wait-time)